### PR TITLE
Quality of life and debian 12 fixes

### DIFF
--- a/config/config.fish
+++ b/config/config.fish
@@ -6,6 +6,6 @@ if status is-interactive
     set -g theme_display_hostname yes
     set -g theme_nerd_fonts yes
 
-    alias ls="eza"
-    alias cat="bat"
+    abbr -a ls "eza"
+    abbr -a cat "bat"
 end

--- a/config/config_debian.fish
+++ b/config/config_debian.fish
@@ -6,6 +6,6 @@ if status is-interactive
     set -g theme_display_hostname yes
     set -g theme_nerd_fonts yes
 
-    alias ls="eza"
-    alias cat="batcat"
+    abbr -a ls "eza"
+    abbr -a cat "batcat"
 end

--- a/distros/arch/setup.sh
+++ b/distros/arch/setup.sh
@@ -88,7 +88,7 @@ done
 setups+=(fish)
 
 # Add console apps
-packages+=" fish neofetch kwrite htop btop neovim lynis github-cli eza bat zram-generator wget curl ark filelight"
+packages+=" fish neofetch kwrite htop btop neovim github-cli eza bat zram-generator wget curl ark filelight"
 
 # Add development packages
 packages+=" git base-devel"

--- a/distros/arch/setup.sh
+++ b/distros/arch/setup.sh
@@ -71,12 +71,7 @@ for package in $packages; do
             ;;
 
         rustup )
-            aur+=("$package")
-    
             setups+=(rust)
-
-            # Remove package
-            packages=${packages//"$package"/}
             ;;
 
         nodejs )

--- a/distros/debian/README.md
+++ b/distros/debian/README.md
@@ -10,7 +10,6 @@ This script is only intended for Debian/UBuntu with KDE desktop and Linux mint w
 * Adds the following command line utilities: fish, neofetch, htop, btop, neovim
 * Add lynis for auditing your system
 * Copies fish config
-* Installs NvChad or Astrovim for neovim
 * Downloads and installs Microsoft and hack nerd fonts
 * Configures flatpak and installs my most used apps
 * Installs QEMU/KVM

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -144,7 +144,8 @@ if grep -iq "kde neon" /etc/os-release; then
     rm -v "volian-*.deb"
 elif grep -iq ID=debian /etc/os-release; then
     # Add extra repositories to debian
-    printf "\ndeb http://deb.debian.org/debian/ bookworm main contrib non-free firmware" | sudo tee -a /etc/apt/sources.list
+    sudo apt install software-properties-common -y
+    sudo apt-add-repository contrib non-free -y
 fi
 
 # Add 32 bit support if it's not available

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -130,6 +130,9 @@ if grep -iq "kde neon" /etc/os-release; then
     sudo apt install ./volian-nala.deb
 
     rm -v "volian-*.deb"
+elif grep -iq ID=debian /etc/os-release; then
+    # Add extra repositories to debian
+    deb http://deb.debian.org/debian/ bookworm main contrib non-free
 fi
 
 # Add 32 bit support if it's not available

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -122,9 +122,6 @@ if whiptail --title "Remove discover" --yesno "Would you like to remove discover
 fi
 
 if grep -iq "kde neon" /etc/os-release; then
-    # Add 32 bit support to kde neon, mostly for steam to work
-    sudo dpkg --add-architecture i386
-
     # Download files for installing nala
     wget -O 'volian-keyring.deb' "https://gitlab.com/volian/volian-archive/uploads/d9473098bc12525687dc9aca43d50159/volian-archive-keyring_0.2.0_all.deb"
     sudo apt install ./volian-keyring.deb
@@ -133,6 +130,12 @@ if grep -iq "kde neon" /etc/os-release; then
     sudo apt install ./volian-nala.deb
 
     rm -v "volian-*.deb"
+fi
+
+# Add 32 bit support if it's not available
+# shellcheck disable=SC2046
+if [ -z $(dpkg --print-foreign-architectures) ]; then
+    sudo dpkg --add-architecture i386
 fi
 
 sudo apt update

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -126,7 +126,7 @@ done
 setups+=(fish)
 
 # Add console apps
-packages+=" git build-essential fish neofetch kwrite htop btop neovim lynis gh bat curl wget gpg"
+packages+=" git build-essential fish neofetch kwrite htop btop neovim gh bat curl wget gpg"
 
 # Ms fonts installer and fontconfig
 packages+=" ttf-mscorefonts-installer fontconfig"

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -56,8 +56,6 @@ for package in $packages; do
             ;;
 
         steam ) 
-            packages+=" steam-devices"
-
             # steam package has a different name for debian
             if grep -iq ID=debian /etc/os-release; then
                 # Remove package
@@ -65,6 +63,8 @@ for package in $packages; do
 
                 packages+=" steam-installer"
             fi
+
+            packages+=" steam-devices"
             ;;
 
         lutris )

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -48,7 +48,13 @@ for package in $packages; do
             # Remove package
             packages=${packages//"$package"/}
 
-            packages+=" qemu-kvm libvirt-clients libvirt-daemon-system bridge-utils virtinst libvirt-daemon virt-manager"
+            packages+=" libvirt-clients libvirt-daemon-system bridge-utils virtinst libvirt-daemon virt-manager"
+
+            if grep -iq ID=debian /etc/os-release; then
+                packages+=" qemu-system-x86"
+            else
+                packages+=" qemu-kvm"
+            fi
 
             services+=(libvirtd.service)
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -188,15 +188,7 @@ for app in "${setups[@]}"; do
         hacknerd )
             setup_hacknerd_fonts
             ;;
-
-        nvchad )
-            setup_nvchad
-            ;;
-
-        astrovim )
-            setup_astrovim
-            ;;
-
+            
         rust )
             setup_rust
             ;;

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -11,7 +11,7 @@ packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
     "goverlay mangohud gamemode" "Gaming overlay" OFF \
-    "steam steam-devices" "Steam" OFF \
+    "steam" "Steam" OFF \
     "haruna" "Haruna media player" ON \
     "celluloid" "Celluloid media player" ON \
     "vlc" "VLC media player" ON \
@@ -53,6 +53,10 @@ for package in $packages; do
             services+=(libvirtd.service)
 
             usergroups+=(libvirt)
+            ;;
+
+        steam ) 
+            packages+=" steam-devices"
             ;;
 
         lutris )

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -57,6 +57,14 @@ for package in $packages; do
 
         steam ) 
             packages+=" steam-devices"
+
+            # steam package has a different name for debian
+            if grep -iq ID=debian /etc/os-release; then
+                # Remove package
+                packages=${packages//"$package"/}
+
+                packages+=" steam-installer"
+            fi
             ;;
 
         lutris )
@@ -136,7 +144,7 @@ if grep -iq "kde neon" /etc/os-release; then
     rm -v "volian-*.deb"
 elif grep -iq ID=debian /etc/os-release; then
     # Add extra repositories to debian
-    deb http://deb.debian.org/debian/ bookworm main contrib non-free
+    printf "\ndeb http://deb.debian.org/debian/ bookworm main contrib non-free firmware" | sudo tee -a /etc/apt/sources.list
 fi
 
 # Add 32 bit support if it's not available

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -88,7 +88,7 @@ done
 setups+=(fish)
 
 # Add console apps
-packages+=" fish neofetch kwrite htop btop neovim lynis gh eza bat"
+packages+=" fish neofetch kwrite htop btop neovim gh eza bat"
 
 # Add latest dnf
 packages+=" dnf5 dnf5-plugins"

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -11,7 +11,7 @@ packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
     "goverlay mangohud gamemode" "Gaming overlay" OFF \
-    "steam steam-devices" "Steam" OFF \
+    "steam" "Steam" OFF \
     "haruna" "Haruna media player" ON \
     "celluloid" "Celluloid media player" ON \
     "vlc" "VLC media player" ON \
@@ -55,6 +55,10 @@ for package in $packages; do
 
             # Remove package
             packages=${packages//"$package"/}
+            ;;
+
+        steam )
+            packages+=" steam-devices"
             ;;
 
         vscode )

--- a/distros/opensuse/README.md
+++ b/distros/opensuse/README.md
@@ -16,6 +16,6 @@ This script is only intended for OpenSUSE Tumbleweed with KDE desktop, it may no
 * Installs NvChad or Astrovim for neovim
 * Downloads and installs Microsoft and hack nerd fonts
 * Configures flatpak and installs my most used apps
-* Experimental option to install QEMU/KVM (Internet doesn't seem to work with either NAT or a bridge for now)
+* Experimental option to install QEMU/KVM
 * Installs the GitHub CLI
 * Optionally sets hostname

--- a/distros/opensuse/setup.sh
+++ b/distros/opensuse/setup.sh
@@ -33,7 +33,7 @@ packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
     "goverlay mangohud gamemode" "Gaming overlay" OFF \
-    "steam steam-devices" "Steam" OFF \
+    "steam" "Steam" OFF \
     "haruna" "Haruna media player" ON \
     "celluloid" "Celluloid media player" ON \
     "vlc" "VLC media player" ON \
@@ -82,6 +82,10 @@ for package in $packages; do
             services+=(libvirtd.service)
 
             usergroups+=(libvirt)
+            ;;
+
+        steam )
+            packages+=" steam-devices"
             ;;
 
         vscode|dotnet )

--- a/distros/opensuse/setup.sh
+++ b/distros/opensuse/setup.sh
@@ -119,7 +119,7 @@ done
 # Add fish setup to be last
 setups+=(fish)
 
-packages+=" opi fish neofetch kwrite htop btop neovim lynis gh eza bat fetchmsttfonts systemd-zram-service"
+packages+=" opi fish neofetch kwrite htop btop neovim gh eza bat fetchmsttfonts systemd-zram-service"
 
 # Remove extra whitespace
 packages=$(echo "$packages" | xargs)

--- a/post_install.sh
+++ b/post_install.sh
@@ -47,9 +47,9 @@ if [ ! -x "/usr/bin/whiptail" ]; then
   echo -e "${RED}whiptail is not installed! Please install newt to proceed!${NC}"
 
   case $package_manager in
-    "zypper") sudo zypper -vv in -y newt
+    "zypper") sudo zypper -vv install -y newt
         ;;
-    "dnf") sudo dnf in -y newt
+    "dnf") sudo dnf install -y newt
         ;;
     "pacman") sudo pacman -S --noconfirm whiptail
         ;;

--- a/post_install.sh
+++ b/post_install.sh
@@ -131,7 +131,7 @@ if hostname=$(whiptail --title "Hostname" --inputbox "Type in your hostname\nLea
 fi
 
 # Check if lynis is installed and ask for audit 
-if [ -x /usr/bin/lynis ] && whiptail --yesno "Would you like to run an audit?" 0 0; then
+if [ -x "$(command -v lynis)" ] && whiptail --yesno "Would you like to run an audit?" 0 0; then
   sudo lynis audit system
 fi
 

--- a/post_install.sh
+++ b/post_install.sh
@@ -130,12 +130,6 @@ if hostname=$(whiptail --title "Hostname" --inputbox "Type in your hostname\nLea
     fi
 fi
 
-# Check if lynis is installed and ask for audit 
-# shellcheck disable=SC2235
-if ([ -x "$(command -v lynis)" ] || [ -x /usr/sbin/lynis ]) && whiptail --yesno "Would you like to run an audit?" 0 0; then
-  sudo lynis audit system
-fi
-
 echo -e "${YELLOW}Please reboot for flatpak's path and QEMU to work${NC}"
 echo -e "${YELLOW}Please run 'gh auth login' to start using GitHub CLI${NC}"
 echo -e "${GREEN}Post install complete, enjoy your new distro!${NC}"

--- a/post_install.sh
+++ b/post_install.sh
@@ -131,7 +131,8 @@ if hostname=$(whiptail --title "Hostname" --inputbox "Type in your hostname\nLea
 fi
 
 # Check if lynis is installed and ask for audit 
-if [ -x "$(command -v lynis)" ] && whiptail --yesno "Would you like to run an audit?" 0 0; then
+# shellcheck disable=SC2235
+if ([ -x "$(command -v lynis)" ] || [ -x /usr/sbin/lynis ]) && whiptail --yesno "Would you like to run an audit?" 0 0; then
   sudo lynis audit system
 fi
 


### PR DESCRIPTION
- **debian: nvchad and astrovim setups removed because nvim is too outdated**
- **root: newt install commands expanded**
- **debian and opensuse: readmes corrected**
- **shared: configs use abbreviation instead of aliases**
- **arch: rustup removed from aur, all: lynis checked with command instead of path**
- **debian/ubuntu: add 32 bit support if it's not available**
- **debian/ubuntu: add extra repos for debian**
- **all: steam and steam devices sepperated**
- **debian: add contrib repo to debian**
- **debian: repo adding fixed**
- **debian: steam package name fixed**
- **debian: qemu package names fixed**
- **all: better check for lynis**
- **all: lynis removed**
