### PR TITLE
Readme overhaul (download script added) and firefox policy added for security

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bash ./post_install.sh
 
 ### Experimental
 
-Download scripts
+#### Download scripts
 ```console
 wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/maintanence.zip"
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Tested distros:
 
 Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"```
 
-Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd post-install-scripts```
+Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-master```
 
 Make executable ```chmod +x ./post_install.sh```
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Tested distros:
 
 ## How to run
 
-Download scripts ```wget -O "$HOME/Downloads/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"```
+Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"```
 
-Navigate and unzip ```cd "$HOME/Downloads" && unzip post-install-scripts.zip && cd post-install-scripts```
+Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd post-install-scripts```
 
 Make executable ```chmod +x ./post_install.sh```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Tested distros:
 
 ## How to run
 
+Download scripts ```wget -O "$HOME/Downloads/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"```
+
+Navigate and unzip ```cd "$HOME/Downloads" && unzip post-install-scripts.zip && cd post-install-scripts```
+
 Make executable ```chmod +x ./post_install.sh```
 
 Run ```./post_install.sh ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,4 @@ Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" 
 
 Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-master```
 
-Make executable ```chmod +x ./post_install.sh```
-
-Run ```./post_install.sh ```
+Run ```bash ./post_install.sh ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" 
 
 Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-master```
 
-Run ```bash ./post_install.sh ```
+Run ```bash ./post_install.sh```
 
 ### Experimental
 
@@ -47,6 +47,7 @@ Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" 
 
 Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-maintanence```
 
-Run ```bash ./post_install.sh ```
+Run ```bash ./post_install.sh```
 
-### Add --copy-firefox-policy to copy the firefox policy
+### To copy the firefox policy
+Run with ```bash ./post_install.sh --copy-firefox-policy```

--- a/README.md
+++ b/README.md
@@ -35,19 +35,40 @@ Tested distros:
 
 ### Stable
 
-Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"```
+#### Download scripts
+```console
+wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"
+```
 
-Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-master```
+#### Navigate and unzip
+```console
+cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-master
+```
 
-Run ```bash ./post_install.sh```
+#### Run
+```console
+bash ./post_install.sh
+```
 
 ### Experimental
 
-Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/maintanence.zip"```
+Download scripts
+```console
+wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/maintanence.zip"
+```
 
-Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-maintanence```
+#### Navigate and unzip
+```console
+cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-maintanence
+```
 
-Run ```bash ./post_install.sh```
+#### Run
+```console
+bash ./post_install.sh
+```
 
 ### To copy the firefox policy
-Run with ```bash ./post_install.sh --copy-firefox-policy```
+#### Run with
+```console
+bash ./post_install.sh --copy-firefox-policy
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Post install script for Linux
 
 ## Supported distros
-* OpenSUSE
-* Fedora
-* Debian
-* Arch linux
+* [OpenSUSE][1]
+* [Fedora][2]
+* [Debian][3]
+* [Arch linux][4]
 
 Tested distros:
 * OpenSUSE Tumbleweed
@@ -72,3 +72,8 @@ bash ./post_install.sh
 ```console
 bash ./post_install.sh --copy-firefox-policy
 ```
+
+[1]: distros/opensuse#readme
+[2]: distros/fedora#readme
+[3]: distros/debian#readme
+[4]: distros/arch#readme

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" 
 Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-maintanence```
 
 Run ```bash ./post_install.sh ```
+
+### Add --copy-firefox-policy to copy the firefox policy

--- a/README.md
+++ b/README.md
@@ -33,8 +33,18 @@ Tested distros:
 
 ## How to run
 
+### Stable
+
 Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/master.zip"```
 
 Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-master```
+
+Run ```bash ./post_install.sh ```
+
+### Experimental
+
+Download scripts ```wget -O "$(xdg-user-dir DOWNLOAD)/post-install-scripts.zip" "https://github.com/KnightTheCoder/Linux-Distro-Post-Install-Scripts/archive/refs/heads/maintanence.zip"```
+
+Navigate and unzip ```cd "$(xdg-user-dir DOWNLOAD)" && unzip post-install-scripts.zip && cd Linux-Distro-Post-Install-Scripts-maintanence```
 
 Run ```bash ./post_install.sh ```

--- a/config/policies.json
+++ b/config/policies.json
@@ -1,0 +1,38 @@
+{
+    "policies": {
+        "AppAutoUpdate":false,
+        "DisableAppUpdate":true,
+        "DisableTelemetry":true,
+        "DisableFirefoxStudies":true,
+        "Extensions":{
+            "Install":[
+                "https://addons.mozilla.org/firefox/downloads/file/4261710/ublock_origin-1.57.2.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4232703/privacy_badger17-2024.2.6.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4262820/canvasblocker-1.10.1.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4098688/user_agent_string_switcher-0.5.0.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4251866/localcdn_fork_of_decentraleyes-2.6.65.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4250017/enhancer_for_youtube-2.0.123.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4262984/darkreader-4.9.83.xpi"
+            ]
+        },
+        "EnableTrackingProtection":{
+            "Value":true,
+            "CryptoMining":true,
+            "Fingerprinting":true
+        },
+        "OfferToSaveLogins":false,
+        "Permissions":{
+            "Notifications":{
+                "BlockNewRequests":true
+            },
+            "Autoplay":{
+                "Default":"block-audio-video"
+            }
+        },
+        "PictureInPicture":{
+            "Enabled":false
+        },
+        "PromptForDownloadLocation":true,
+        "DisableFormHistory":true
+    }
+}

--- a/distros/arch/setup.sh
+++ b/distros/arch/setup.sh
@@ -196,6 +196,12 @@ yay -S "${aur[@]}" --needed
 # Setup zram
 printf "[zram0]\n zram-size = ram / 2\n compression-algorithm = zstd\n swap-priority = 100\n fs-type = swap\n" | sudo tee /etc/systemd/zram-generator.conf
 
+# Add user to groups
+for group in "${usergroups[@]}"; do
+    sudo groupadd "$group"
+    sudo usermod -a -G "$group" "$USER"
+done
+
 # Run setups
 for app in "${setups[@]}"; do
     case $app in
@@ -252,9 +258,4 @@ done
 # Start services
 for serv in "${services[@]}"; do
     sudo systemctl enable --now "$serv"
-done
-
-# Add user to groups
-for group in "${usergroups[@]}"; do
-    sudo usermod -a -G "$group" "$USER"
 done

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -41,7 +41,7 @@ packages+=" git build-essential fish neofetch kwrite htop btop neovim gh bat cur
 
 shells=$(choose_shells)
 
-packages+=" $shells"
+packages+=" starship-install $shells"
 
 # Remove new lines
 packages=$(echo "$packages"| tr "\n" " ")
@@ -66,9 +66,14 @@ for package in $packages; do
             setups+=(zsh)
             ;;
 
+        starship-install )
+            setups+=(starship-install)
+
+            packages=${packages//"$package"/}
+            ;;
+
         starship )
             setups+=(starship)
-            setups+=(tarship-install)
 
             packages=${packages//"$package"/}
             ;;

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -402,7 +402,7 @@ for app in "${setups[@]}"; do
             setup_zsh
             ;;
 
-        tarship-install )
+        starship-install )
             setup_starship_install
             ;;
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -41,7 +41,7 @@ packages+=" git build-essential neofetch kwrite htop btop neovim gh bat curl wge
 
 shells=$(choose_shells)
 
-if [[ $shells == "*starship*" ]]; then
+if [[ $shells == *"starship"* ]]; then
     shells="starship-install $shells"
 fi
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -41,7 +41,7 @@ packages+=" git build-essential neofetch kwrite htop btop neovim gh bat curl wge
 
 shells=$(choose_shells)
 
-if [[ $shells == "starship" ]]; then
+if [[ $shells == "*starship*" ]]; then
     shells="starship-install $shells"
 fi
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -37,7 +37,7 @@ packages=$(
     3>&1 1>&2 2>&3
 )
 
-packages+=" git build-essential fish neofetch kwrite htop btop neovim gh bat curl wget gpg ttf-mscorefonts-installer fontconfig"
+packages+=" git build-essential neofetch kwrite htop btop neovim gh bat curl wget gpg ttf-mscorefonts-installer fontconfig"
 
 shells=$(choose_shells)
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -68,6 +68,7 @@ for package in $packages; do
 
         starship )
             setups+=(starship)
+            setups+=(tarship-install)
 
             packages=${packages//"$package"/}
             ;;
@@ -390,6 +391,10 @@ for app in "${setups[@]}"; do
 
         zsh )
             setup_zsh
+            ;;
+
+        tarship-install )
+            setup_starship_install
             ;;
 
         starship )

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -41,7 +41,11 @@ packages+=" git build-essential fish neofetch kwrite htop btop neovim gh bat cur
 
 shells=$(choose_shells)
 
-packages+=" starship-install $shells"
+if [[ $shells == "starship" ]]; then
+    shells="starship-install $shells"
+fi
+
+packages+=" $shells"
 
 # Remove new lines
 packages=$(echo "$packages"| tr "\n" " ")

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -234,6 +234,12 @@ sudo nala install -y $packages
 # Build font cache for ms fonts
 sudo fc-cache -f -v
 
+# Add user to groups
+for group in "${usergroups[@]}"; do
+    sudo groupadd "$group"
+    sudo usermod -a -G "$group" "$USER"
+done
+
 # Run setups
 for app in "${setups[@]}"; do
     case $app in
@@ -395,9 +401,4 @@ done
 # Start services
 for serv in "${services[@]}"; do
     sudo systemctl enable --now "$serv"
-done
-
-# Add user to groups
-for group in "${usergroups[@]}"; do
-    sudo usermod -a -G "$group" "$USER"
 done

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -70,6 +70,8 @@ for package in $packages; do
 
         starship )
             setups+=(starship)
+
+            packages=${packages//"$package"/}
             ;;
 
         qemu )

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -291,7 +291,7 @@ for app in "${setups[@]}"; do
             setup_zsh
             ;;
 
-        tarship-install )
+        starship-install )
             setup_starship_install
             ;;
 

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -43,7 +43,7 @@ packages+=" fish neofetch kwrite htop btop neovim gh eza bat dnf5 dnf5-plugins c
 
 shells=$(choose_shells)
 
-if [[ $shells == "starship" ]]; then
+if [[ $shells == "*starship*" ]]; then
     shells="starship-install $shells"
 fi
 

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -70,6 +70,7 @@ for package in $packages; do
 
         starship )
             setups+=(starship)
+            setups+=(starship-install)
 
             packages=${packages//"$package"/}
             ;;
@@ -279,6 +280,10 @@ for app in "${setups[@]}"; do
 
         zsh )
             setup_zsh
+            ;;
+
+        tarship-install )
+            setup_starship_install
             ;;
 
         starship )

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -43,7 +43,7 @@ packages+=" fish neofetch kwrite htop btop neovim gh eza bat dnf5 dnf5-plugins c
 
 shells=$(choose_shells)
 
-if [[ $shells == "*starship*" ]]; then
+if [[ $shells == *"starship"* ]]; then
     shells="starship-install $shells"
 fi
 

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -43,7 +43,7 @@ packages+=" fish neofetch kwrite htop btop neovim gh eza bat dnf5 dnf5-plugins c
 
 shells=$(choose_shells)
 
-packages+=" $shells"
+packages+=" starship-install $shells"
 
 # Remove new lines
 packages=$(echo "$packages"| tr "\n" " ")
@@ -68,9 +68,15 @@ for package in $packages; do
             setups+=(zsh)
             ;;
 
-        starship )
-            setups+=(starship)
+        starship-install )
             setups+=(starship-install)
+
+            packages=${packages//"$package"/}
+            ;;
+
+        starship )
+            setups+=(starship-install)
+            setups+=(starship)
 
             packages=${packages//"$package"/}
             ;;

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -75,7 +75,6 @@ for package in $packages; do
             ;;
 
         starship )
-            setups+=(starship-install)
             setups+=(starship)
 
             packages=${packages//"$package"/}

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -43,7 +43,11 @@ packages+=" fish neofetch kwrite htop btop neovim gh eza bat dnf5 dnf5-plugins c
 
 shells=$(choose_shells)
 
-packages+=" starship-install $shells"
+if [[ $shells == "starship" ]]; then
+    shells="starship-install $shells"
+fi
+
+packages+=" $shells"
 
 # Remove new lines
 packages=$(echo "$packages"| tr "\n" " ")

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -183,6 +183,12 @@ sudo dnf install -y $packages
 # Install msfonts
 sudo rpm -i https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
 
+# Add user to groups
+for group in "${usergroups[@]}"; do
+    sudo groupadd "$group"
+    sudo usermod -a -G "$group" "$USER"
+done
+
 # Run setups
 for app in "${setups[@]}"; do
     case $app in
@@ -284,9 +290,4 @@ done
 # Start services
 for serv in "${services[@]}"; do
     sudo systemctl enable --now "$serv"
-done
-
-# Add user to groups
-for group in "${usergroups[@]}"; do
-    sudo usermod -a -G "$group" "$USER"
 done

--- a/distros/opensuse/setup.sh
+++ b/distros/opensuse/setup.sh
@@ -229,6 +229,12 @@ for repo in $repos; do
     esac
 done
 
+# Add user to groups
+for group in "${usergroups[@]}"; do
+    sudo groupadd "$group"
+    sudo usermod -a -G "$group" "$USER"
+done
+
 # Run setups
 for app in "${setups[@]}"; do
     case $app in
@@ -285,11 +291,6 @@ done
 # Start services
 for serv in "${services[@]}"; do
     sudo systemctl enable --now "$serv"
-done
-
-# Add user to groups
-for group in "${usergroups[@]}"; do
-    sudo usermod -a -G "$group" "$USER"
 done
 
 create_snapshot 1

--- a/post_install.sh
+++ b/post_install.sh
@@ -35,7 +35,7 @@ function get_package_manager() {
   fi
 }
 
-if [ $EUID -eq 0 ]; then
+if [ "$EUID" == 0 ]; then
   echo -e "${RED}Please run without root!${NC}"
   exit 1
 fi

--- a/post_install.sh
+++ b/post_install.sh
@@ -101,6 +101,11 @@ fi
 
 echo -e "${GREEN}Your chosen distro is $(resolve_distro "$chosen_distro")${NC}"
 
+if [[ $1 == "--copy-firefox-policy" ]]; then
+  sudo mkdir -pv "/etc/firefox/policies"
+  sudo cp -fv "config/policies.json" "/etc/firefox/policies"
+fi
+
 echo -e "${GREEN}Checking package manager and distro combination...${NC}"
 if [[ $chosen_distro = "1" && $package_manager = "zypper" ]]; then
   echo -e "${GREEN}zypper found for OpenSUSE!${NC}"

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -138,26 +138,26 @@ function setup_zsh() {
     sudo chsh -s /bin/zsh
 }
 
-setup_starship_install() {
-     if [ ! -x "$(command -v starship)" ]; then
+function setup_starship_install() {
+     if [[ ! -x "$(command -v starship)" ]]; then
         curl -sS https://starship.rs/install.sh | sh
     fi
 }
 
 function setup_starship() {
-    if [ ! -x "$(command -v starship)" ]; then
+    if [[ ! -x "$(command -v starship)" ]]; then
         return
     fi
 
-    if [ -x "$(command -v bash)" ] && ! grep -iq starship "$HOME/.bashrc"; then
+    if [[ -x "$(command -v bash)" ]] && ! grep -iq starship "$HOME/.bashrc"; then
         printf "\neval \"\$(starship init bash)\"" | tee -a "$HOME/.bashrc"
     fi
 
-    if [ -x "$(command -v fish)" ] && ! grep -iq starship "$HOME/.config/fish/config.fish"; then
+    if [[ -x "$(command -v fish)" ]] && ! grep -iq starship "$HOME/.config/fish/config.fish"; then
         printf "\nstarship init fish | source" | tee -a "$HOME/.config/fish/config.fish"
     fi
 
-    if [ -x "$(command -v zsh)" ] && ! grep -iq starship "$HOME/.zshrc"; then
+    if [[ -x "$(command -v zsh)" ]] && ! grep -iq starship "$HOME/.zshrc"; then
         printf "\neval \"\$(starship init zsh)\"" | tee -a "$HOME/.zshrc"
     fi
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -187,9 +187,9 @@ function choose_nvim_config() {
 function choose_shells() {
     shells=$(
         whiptail --title "Shells" --separate-output --checklist "Select the shells you'd like to install" 0 0 0 \
-            "starship" "Starship prompt" ON \
             "fish" "Fish shell" ON \
             "zsh" "zsh shell" OFF \
+            "starship" "Starship prompt" ON \
             3>&1 1>&2 2>&3
     )
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -187,13 +187,12 @@ function choose_nvim_config() {
 function choose_shells() {
     shells=$(
         whiptail --title "Shells" --separate-output --checklist "Select the shells you'd like to install" 0 0 0 \
-            "starship" "Starship prompt" ON \
             "zsh" "zsh shell" OFF \
             "fish" "Fish shell" ON \
             3>&1 1>&2 2>&3
     )
 
-    echo "$shells"
+    echo "starship $shells"
 }
 
 function setup_nvchad() {

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -35,7 +35,7 @@ function setup_vscode() {
         "bradlc.vscode-tailwindcss"
         "christian-kohler.path-intellisense"
         "codezombiech.gitignore"
-        "csstools.postcss"
+        "vunguyentuan.vscode-postcss"
         "dannyconnell.split-html-attributes"
         "dbaeumer.vscode-eslint"
         "eamodio.gitlens"

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -187,9 +187,9 @@ function choose_nvim_config() {
 function choose_shells() {
     shells=$(
         whiptail --title "Shells" --separate-output --checklist "Select the shells you'd like to install" 0 0 0 \
-            "fish" "Fish shell" ON \
-            "zsh" "zsh shell" OFF \
             "starship" "Starship prompt" ON \
+            "zsh" "zsh shell" OFF \
+            "fish" "Fish shell" ON \
             3>&1 1>&2 2>&3
     )
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -187,12 +187,13 @@ function choose_nvim_config() {
 function choose_shells() {
     shells=$(
         whiptail --title "Shells" --separate-output --checklist "Select the shells you'd like to install" 0 0 0 \
+            "starship" "Starship prompt" ON \
             "fish" "Fish shell" ON \
             "zsh" "zsh shell" OFF \
             3>&1 1>&2 2>&3
     )
 
-    echo "starship $shells"
+    echo "$shells"
 }
 
 function setup_nvchad() {

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -98,11 +98,10 @@ function setup_fish() {
     if [ -d "$HOME/.local/share/omf" ]; then
         echo -e "${YELLOW}oh my fish is already installed!${NC}"
     else
-        echo -e "${YELLOW}Please run 'omf install bobthefish' and exit from fish once it's done so the install can continue${NC}"
+        echo -e "${YELLOW}Please run 'exit' to exit from fish and install the bobthefish theme${NC}"
         curl https://raw.githubusercontent.com/oh-my-fish/oh-my-fish/master/bin/install | fish
+        fish "../../shared/setup.fish"
     fi
-
-    fish "../../shared/setup.fish"
 
     echo -e "${GREEN}Copying fish config...${NC}"
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -187,8 +187,8 @@ function choose_nvim_config() {
 function choose_shells() {
     shells=$(
         whiptail --title "Shells" --separate-output --checklist "Select the shells you'd like to install" 0 0 0 \
-            "zsh" "zsh shell" OFF \
             "fish" "Fish shell" ON \
+            "zsh" "zsh shell" OFF \
             3>&1 1>&2 2>&3
     )
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -138,9 +138,15 @@ function setup_zsh() {
     sudo chsh -s /bin/zsh
 }
 
+setup_starship_install() {
+     if [ ! -x "$(command -v starship)" ]; then
+        curl -sS https://starship.rs/install.sh | sh
+    fi
+}
+
 function setup_starship() {
     if [ ! -x "$(command -v starship)" ]; then
-        curl -sS https://starship.rs/install.sh | sh
+        return
     fi
 
     if [ -x "$(command -v bash)" ] && ! grep -iq starship "$HOME/.bashrc"; then


### PR DESCRIPTION
- **main: sudo check uses == instead of -eq now**
- **readme: download instructions added**
- **readme: download folder updated**
- **readme: directory corrected**
- **readme: running doesn't need to be executable, use bash instead**
- **fedora: starship fix**
- **shared: comment to run omf install bobthefish removed, it will only ask to exit now**
- **readme: updated to list commands for stable and experimental install**
- **added option to copy firefox policies, starship changed to first option when choosing shells**
- **shared: starship is default**
- **shared: fish on top instead of zsh**
- **shared: starship option as first, all: usergroups added before setups(fix for opensuse's flatpak)**
- **shared: starship as last to setup all shells, readme: firefox policy copy updated script**
- **shared: better postcss extension added**
- **readme: better code shown**
- **readme: bold fixed**
- **readme: links to the readmes of distros added**
- **shared: seperate script for installing starship for debian and fedora**
- **debian and fedora: starship-install before shell setups**
- **fedora: starship install fixed**
- **debian and fedora starship new fix**
- **debian: fish removed from default packages**
- **debian and fedora: fixed typo**
- **debian and fedora: starship detection fixed**
- **debian and fedora: starship detection fixed, stars outside**

closes #68 