### PR TITLE
firefox policy additions, golang, xampp, zsh fix for debian

### DIFF
--- a/config/policies.json
+++ b/config/policies.json
@@ -6,6 +6,7 @@
         "DisableFirefoxStudies": true,
         "DisableFormHistory": true,
         "DisablePocket": true,
+        "DisableFeedbackCommands": true,
         "Extensions":{
             "Install":[
                 "https://addons.mozilla.org/firefox/downloads/file/4261710/ublock_origin-1.57.2.xpi",

--- a/config/policies.json
+++ b/config/policies.json
@@ -13,12 +13,6 @@
                 "https://addons.mozilla.org/firefox/downloads/file/4251866/localcdn_fork_of_decentraleyes-2.6.65.xpi"
             ]
         },
-        "Cookies":{
-            "Default":true,
-            "AcceptThirdParty":"never",
-            "RejectTracker":true,
-            "Behavior":"reject-tracker-and-partition-foreign"
-        },
         "EnableTrackingProtection":{
             "Value":true,
             "CryptoMining":true,

--- a/config/policies.json
+++ b/config/policies.json
@@ -10,9 +10,7 @@
                 "https://addons.mozilla.org/firefox/downloads/file/4232703/privacy_badger17-2024.2.6.xpi",
                 "https://addons.mozilla.org/firefox/downloads/file/4262820/canvasblocker-1.10.1.xpi",
                 "https://addons.mozilla.org/firefox/downloads/file/4098688/user_agent_string_switcher-0.5.0.xpi",
-                "https://addons.mozilla.org/firefox/downloads/file/4251866/localcdn_fork_of_decentraleyes-2.6.65.xpi",
-                "https://addons.mozilla.org/firefox/downloads/file/4250017/enhancer_for_youtube-2.0.123.xpi",
-                "https://addons.mozilla.org/firefox/downloads/file/4262984/darkreader-4.9.83.xpi"
+                "https://addons.mozilla.org/firefox/downloads/file/4251866/localcdn_fork_of_decentraleyes-2.6.65.xpi"
             ]
         },
         "Cookies":{

--- a/config/policies.json
+++ b/config/policies.json
@@ -1,9 +1,11 @@
 {
     "policies": {
-        "AppAutoUpdate":false,
-        "DisableAppUpdate":true,
-        "DisableTelemetry":true,
-        "DisableFirefoxStudies":true,
+        "AppAutoUpdate": false,
+        "DisableAppUpdate": true,
+        "DisableTelemetry": true,
+        "DisableFirefoxStudies": true,
+        "DisableFormHistory": true,
+        "DisablePocket": true,
         "Extensions":{
             "Install":[
                 "https://addons.mozilla.org/firefox/downloads/file/4261710/ublock_origin-1.57.2.xpi",
@@ -15,23 +17,25 @@
             ]
         },
         "EnableTrackingProtection":{
-            "Value":true,
-            "CryptoMining":true,
-            "Fingerprinting":true
+            "Value": true,
+            "CryptoMining": true,
+            "Fingerprinting": true,
+            "EmailTracking": true
         },
-        "OfferToSaveLogins":false,
+        "OfferToSaveLogins": false,
         "Permissions":{
             "Notifications":{
-                "BlockNewRequests":true
+                "BlockNewRequests": true
             },
             "Autoplay":{
-                "Default":"block-audio-video"
+                "Default": "block-audio-video"
             }
         },
         "PictureInPicture":{
-            "Enabled":false
+            "Enabled": false
         },
-        "PromptForDownloadLocation":true,
-        "DisableFormHistory":true
+        "PromptForDownloadLocation": true,
+        "AutofillAddressEnabled": false,
+        "AutofillCreditCardEnabled": false
     }
 }

--- a/config/policies.json
+++ b/config/policies.json
@@ -15,6 +15,12 @@
                 "https://addons.mozilla.org/firefox/downloads/file/4262984/darkreader-4.9.83.xpi"
             ]
         },
+        "Cookies":{
+            "Default":true,
+            "AcceptThirdParty":"never",
+            "RejectTracker":true,
+            "Behavior":"reject-tracker-and-partition-foreign"
+        },
         "EnableTrackingProtection":{
             "Value":true,
             "CryptoMining":true,

--- a/config/policies.json
+++ b/config/policies.json
@@ -10,7 +10,8 @@
                 "https://addons.mozilla.org/firefox/downloads/file/4232703/privacy_badger17-2024.2.6.xpi",
                 "https://addons.mozilla.org/firefox/downloads/file/4262820/canvasblocker-1.10.1.xpi",
                 "https://addons.mozilla.org/firefox/downloads/file/4098688/user_agent_string_switcher-0.5.0.xpi",
-                "https://addons.mozilla.org/firefox/downloads/file/4251866/localcdn_fork_of_decentraleyes-2.6.65.xpi"
+                "https://addons.mozilla.org/firefox/downloads/file/4251866/localcdn_fork_of_decentraleyes-2.6.65.xpi",
+                "https://addons.mozilla.org/firefox/downloads/file/4064884/clearurls-1.26.1.xpi"
             ]
         },
         "EnableTrackingProtection":{

--- a/config/policies.json
+++ b/config/policies.json
@@ -36,6 +36,7 @@
         },
         "PromptForDownloadLocation": true,
         "AutofillAddressEnabled": false,
-        "AutofillCreditCardEnabled": false
+        "AutofillCreditCardEnabled": false,
+        "NoDefaultBookmarks": true
     }
 }

--- a/distros/arch/setup.sh
+++ b/distros/arch/setup.sh
@@ -31,6 +31,7 @@ packages=$(
     "dotnet-sdk" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
     "go" "Golang" OFF \
+    "xampp" "XAMPP" OFF \
     "docker" "Docker engine" OFF \
     "docker-desktop" "Docker desktop" OFF \
     "podman" "Podman" OFF \
@@ -127,6 +128,12 @@ for package in $packages; do
             packages+=" npm"
 
             setups+=(npm)
+            ;;
+
+        xampp )
+            packages=${packages//"$package"/}
+
+            setups+=(xampp)
             ;;
 
         docker )
@@ -242,6 +249,10 @@ for app in "${setups[@]}"; do
 
         npm )
             setup_npm
+            ;;
+
+        xampp )
+            setup_xampp
             ;;
 
         flatpak )

--- a/distros/arch/setup.sh
+++ b/distros/arch/setup.sh
@@ -30,6 +30,7 @@ packages=$(
     "nodejs" "Nodejs" OFF \
     "dotnet-sdk" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
+    "go" "Golang" OFF \
     "docker" "Docker engine" OFF \
     "docker-desktop" "Docker desktop" OFF \
     "podman" "Podman" OFF \

--- a/distros/arch/setup.sh
+++ b/distros/arch/setup.sh
@@ -10,7 +10,7 @@ whiptail --title "Arch linux" --msgbox "Welcome to the arch linux script!" 0 0
 packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
-    "goverlay mangohud gamemode" "Gaming overlay" OFF \
+    "gaming-overlay" "Gaming overlay" OFF \
     "steam" "Steam" OFF \
     "itch" "Itch desktop app" OFF \
     "heroic" "Heroic Games Launcher" OFF \
@@ -75,6 +75,12 @@ for package in $packages; do
             setups+=(starship)
             ;;
 
+        gaming-overlay)
+            packages=${packages//"$package"/}
+
+            packages+=" goverlay mangohud gamemode"
+            ;;
+
         qemu )
             packages+=" qemu virt-manager virt-viewer dnsmasq vde2 bridge-utils openbsd-netcat dmidecode"
 
@@ -113,10 +119,6 @@ for package in $packages; do
             setups+=(vscodium)
             ;;
 
-        flatpak )
-            setups+=(flatpak)
-            ;;
-
         rustup )
             setups+=(rust)
             ;;
@@ -137,6 +139,10 @@ for package in $packages; do
             aur+=(docker-desktop)
 
             packages=${packages//"$package"/}
+            ;;
+
+        flatpak )
+            setups+=(flatpak)
             ;;
 
         * ) ;;

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -29,6 +29,7 @@ packages=$(
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
     "golang" "Golang" OFF \
+    "xampp" "XAMPP" OFF \
     "docker" "Docker engine" OFF \
     "docker-desktop" "Docker desktop" OFF \
     "podman" "Podman" OFF \
@@ -181,6 +182,12 @@ for package in $packages; do
             fi
             ;;
 
+        xampp )
+            packages=${packages//"$package"/}
+
+            setups+=(xampp)
+            ;;
+
         docker )
             packages=${packages/"$package"/}
 
@@ -330,6 +337,10 @@ for app in "${setups[@]}"; do
             rm packages-microsoft-prod.deb
 
             sudo nala update && sudo nala install -y dotnet-sdk-8.0
+            ;;
+
+        xampp )
+            setup_xampp
             ;;
 
         docker )

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -286,8 +286,6 @@ for app in "${setups[@]}"; do
             wget -O heroic.deb https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v2.14.0/heroic_2.14.0_amd64.deb
             sudo dpkg -i heroic.deb
             rm -v heroic.deb
-
-            packages=${packages//"$package"/}
             ;;
 
         itch )
@@ -334,7 +332,7 @@ for app in "${setups[@]}"; do
         dotnet )
             wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
             sudo dpkg -i packages-microsoft-prod.deb
-            rm packages-microsoft-prod.deb
+            rm -v packages-microsoft-prod.deb
 
             sudo nala update && sudo nala install -y dotnet-sdk-8.0
             ;;
@@ -413,6 +411,8 @@ for app in "${setups[@]}"; do
 
                 sudo nala update
                 sudo nala install -y eza
+            else
+                echo -e "${YELLOW}eza is already installed!${NC}"
             fi
             ;;
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -28,6 +28,7 @@ packages=$(
     "nodejs" "Nodejs" OFF \
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
+    "golang" "Golang" OFF \
     "docker" "Docker engine" OFF \
     "docker-desktop" "Docker desktop" OFF \
     "podman" "Podman" OFF \
@@ -163,6 +164,14 @@ for package in $packages; do
                 setups+=(dotnet)
             else
                 packages+=" dotnet-sdk-8.0"
+            fi
+            ;;
+
+        golang )
+            if grep -iq ubuntu /etc/os-release; then
+                packages=${packages/"$package"/}
+
+                packages+=" golang-go"
             fi
             ;;
 

--- a/distros/debian/setup.sh
+++ b/distros/debian/setup.sh
@@ -10,7 +10,7 @@ whiptail --title "Debian/Ubuntu" --msgbox "Welcome to the debian/ubuntu script!"
 packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
-    "goverlay mangohud gamemode" "Gaming overlay" OFF \
+    "gaming-overlay" "Gaming overlay" OFF \
     "steam" "Steam" OFF \
     "itch" "Itch desktop app" OFF \
     "heroic" "Heroic Games Launcher" OFF \
@@ -83,6 +83,12 @@ for package in $packages; do
             packages=${packages//"$package"/}
             ;;
 
+        gaming-overlay)
+            packages=${packages//"$package"/}
+
+            packages+=" goverlay mangohud gamemode"
+            ;;
+
         qemu )
             # Remove package
             packages=${packages//"$package"/}
@@ -145,6 +151,16 @@ for package in $packages; do
             packages=${packages//"$package"/}
             ;;
 
+        dotnet )
+            packages=${packages//"$package"/}
+
+            if grep -iq "ID=debian" /etc/os-release; then
+                setups+=(dotnet)
+            else
+                packages+=" dotnet-sdk-8.0"
+            fi
+            ;;
+
         rustup )
             setups+=(rust)
 
@@ -155,16 +171,6 @@ for package in $packages; do
             setups+=(npm)
 
             packages+=" npm"
-            ;;
-
-        dotnet )
-            packages=${packages//"$package"/}
-
-            if grep -iq "ID=debian" /etc/os-release; then
-                setups+=(dotnet)
-            else
-                packages+=" dotnet-sdk-8.0"
-            fi
             ;;
 
         golang )

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -29,6 +29,7 @@ packages=$(
     "nodejs" "Nodejs" OFF \
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
+    "golang" "Golang" OFF \
     "docker" "Docker engine" OFF \
     "docker-desktop" "Docker desktop" OFF \
     "podman" "Podman" OFF \

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -30,6 +30,7 @@ packages=$(
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
     "golang" "Golang" OFF \
+    "xampp" "XAMPP" OFF \
     "docker" "Docker engine" OFF \
     "docker-desktop" "Docker desktop" OFF \
     "podman" "Podman" OFF \
@@ -135,6 +136,12 @@ for package in $packages; do
 
         nodejs )
             setups+=(npm)
+            ;;
+
+        xampp )
+            packages=${packages//"$package"/}
+
+            setups+=(xampp)
             ;;
 
         docker )
@@ -255,6 +262,10 @@ for app in "${setups[@]}"; do
 
         npm )
             setup_npm
+            ;;
+
+        xampp )
+            setup_xampp
             ;;
 
         docker )

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -10,7 +10,7 @@ whiptail --title "Fedora" --msgbox "Welcome to the fedora script!" 0 0
 packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
-    "goverlay mangohud gamemode" "Gaming overlay" OFF \
+    "gaming-overlay" "Gaming overlay" OFF \
     "steam" "Steam" OFF \
     "itch" "Itch desktop app" OFF \
     "heroic" "Heroic Games Launcher" OFF \
@@ -83,6 +83,12 @@ for package in $packages; do
             setups+=(starship)
 
             packages=${packages//"$package"/}
+            ;;
+
+        gaming-overlay)
+            packages=${packages//"$package"/}
+
+            packages+=" goverlay mangohud gamemode"
             ;;
 
         qemu )

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -58,7 +58,7 @@ packages=$(echo "$packages"| tr "\n" " ")
 services=()
 setups=(fish hacknerd)
 usergroups=()
-remove_packages="akregator dragon elisa-player kaddressbook kmahjongg kmail kontact kmines konversation kmouth korganizer kpat kolourpaint qt5-qdbusviewer \"libreoffice*\""
+remove_packages="akregator dragon elisa-player kaddressbook kmahjongg kmail kontact kmines konversation kmouth korganizer kpat kolourpaint qt5-qdbusviewer"
 
 nvim_config=$(choose_nvim_config)
 setups+=("$nvim_config")
@@ -298,7 +298,7 @@ for app in "${setups[@]}"; do
                 sudo flatpak remote-delete fedora
             fi
             
-            setup_flatpak "org.libreoffice.LibreOffice"
+            setup_flatpak
             ;;
 
         fish )

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -198,7 +198,7 @@ sudo dnf upgrade -y --refresh
 sudo dnf remove -y $remove_packages
 
 # Install codecs
-sudo dnf group install -y Multimedia
+sudo dnf group install -y Multimedia --allowerasing
 
 # Install packages
 # shellcheck disable=SC2086

--- a/distros/fedora/setup.sh
+++ b/distros/fedora/setup.sh
@@ -198,7 +198,7 @@ sudo dnf upgrade -y --refresh
 sudo dnf remove -y $remove_packages
 
 # Install codecs
-sudo dnf install -y gstreamer1-plugins-{bad-\*,good-\*,base} gstreamer1-plugin-openh264 gstreamer1-plugin-libav --exclude=gstreamer1-plugins-bad-free-devel lame* --exclude=lame-devel 
+sudo dnf group install -y Multimedia
 
 # Install packages
 # shellcheck disable=SC2086

--- a/distros/opensuse/setup.sh
+++ b/distros/opensuse/setup.sh
@@ -53,6 +53,7 @@ packages=$(
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
     "golang" "Golang" OFF \
+    "xampp" "XAMPP" OFF \
     "docker" "Docker engine" OFF \
     "podman" "Podman" OFF \
     "distrobox" "Distrobox" OFF \
@@ -171,6 +172,12 @@ for package in $packages; do
             packages+=" go go-doc"
             ;;
 
+        xampp )
+            packages=${packages//"$package"/}
+
+            setups+=(xampp)
+            ;;
+
         docker )
             packages+=" docker-compose docker-compose-switch"
             services+=(docker.service)
@@ -281,6 +288,10 @@ for app in "${setups[@]}"; do
 
         npm )
             setup_npm
+            ;;
+
+        xampp )
+            setup_xampp
             ;;
 
         flatpak )

--- a/distros/opensuse/setup.sh
+++ b/distros/opensuse/setup.sh
@@ -32,7 +32,7 @@ whiptail --title "OpenSUSE" --msgbox "Welcome to the OpenSUSE script!" 0 0
 packages=$(
     whiptail --title "Install List" --separate-output --checklist "Choose what to install/configure" 0 0 0 \
     "lutris" "Lutris" OFF \
-    "goverlay mangohud gamemode" "Gaming overlay" OFF \
+    "gaming-overlay" "Gaming overlay" OFF \
     "steam" "Steam" OFF \
     "itch" "Itch desktop app" OFF \
     "heroic" "Heroic Games Launcher" OFF \
@@ -52,7 +52,7 @@ packages=$(
     "nodejs" "Nodejs" OFF \
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
-    "go" "Golang" OFF \
+    "golang" "Golang" OFF \
     "docker" "Docker engine" OFF \
     "podman" "Podman" OFF \
     "distrobox" "Distrobox" OFF \
@@ -96,6 +96,12 @@ for package in $packages; do
 
         starship )
             setups+=(starship)
+            ;;
+        
+        gaming-overlay)
+            packages=${packages//"$package"/}
+
+            packages+=" goverlay mangohud gamemode"
             ;;
 
         qemu )
@@ -159,7 +165,7 @@ for package in $packages; do
             setups+=(npm)
             ;;
 
-        go )
+        golang )
             packages=${packages//"$package"/}
 
             packages+=" go go-doc"

--- a/distros/opensuse/setup.sh
+++ b/distros/opensuse/setup.sh
@@ -52,6 +52,7 @@ packages=$(
     "nodejs" "Nodejs" OFF \
     "dotnet" ".NET sdk" OFF \
     "rustup" "Rust" OFF \
+    "go" "Golang" OFF \
     "docker" "Docker engine" OFF \
     "podman" "Podman" OFF \
     "distrobox" "Distrobox" OFF \
@@ -156,6 +157,12 @@ for package in $packages; do
             packages+=" nodejs-default"
 
             setups+=(npm)
+            ;;
+
+        go )
+            packages=${packages//"$package"/}
+
+            packages+=" go go-doc"
             ;;
 
         docker )

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -230,9 +230,10 @@ function setup_rust() {
 }
 
 function setup_xampp() {
-    wget -o xampp-linux-installer.run https://sourceforge.net/projects/xampp/files/XAMPP%20Linux/8.2.12/xampp-linux-x64-8.2.12-0-installer.run/download
+    wget -O xampp-linux-installer.run https://sourceforge.net/projects/xampp/files/XAMPP%20Linux/8.2.12/xampp-linux-x64-8.2.12-0-installer.run/download
     chmod +x ./xampp-linux-installer.run
     sudo ./xampp-linux-installer.run
+    rm -rv ./xampp-linux-installer.run
 }
 
 function setup_flatpak() {

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -258,6 +258,7 @@ function setup_flatpak() {
         "com.brave.Browser" "Brave browser" OFF \
         "net.mullvad.MullvadBrowser" "Mullavad Browser" OFF \
         "org.libreoffice.LibreOffice" "Libreoffice" OFF \
+        "org.onlyoffice.desktopeditors" "ONLYOFFICE Desktop Editors" OFF \
         "org.qbittorrent.qBittorrent" "qbittorrent bittorrent client" OFF \
         "com.transmissionbt.Transmission" "Transmission bittorrent client" OFF \
         3>&1 1>&2 2>&3

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -229,6 +229,12 @@ function setup_rust() {
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 }
 
+function setup_xampp() {
+    wget -o xampp-linux-installer.run https://sourceforge.net/projects/xampp/files/XAMPP%20Linux/8.2.12/xampp-linux-x64-8.2.12-0-installer.run/download
+    chmod +x ./xampp-linux-installer.run
+    sudo ./xampp-linux-installer.run
+}
+
 function setup_flatpak() {
     local extra_apps=("$@")
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -114,7 +114,7 @@ function setup_fish() {
 }
 
 function setup_zsh() {
-    if [ -d "$HOME/.prezto" ]; then
+    if [ -d "$HOME/.zprezto" ]; then
         echo -e "${GREEN}prezto already setup${NC}"
         return
     fi
@@ -151,6 +151,7 @@ function setup_starship_install() {
 
 function setup_starship() {
     if [[ ! -x "$(command -v starship)" ]]; then
+        echo -e "${GREEN}Starship is already setup${NC}"
         return
     fi
 

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -133,7 +133,12 @@ function setup_zsh() {
     sed -i "42i 'zsh-abbr' \\\\" "$HOME/.zpreztorc"
 
     mkdir -p "$HOME/.config/zsh-abbr"
-    printf "abbr cat=bat\nabbr ls=eza" > "$HOME/.config/zsh-abbr/user-abbreviations"
+
+    bat_fullname=bat
+    if grep -iq debian /etc/os-release; then
+        bat_fullname=batcat
+    fi
+    printf "abbr cat=%s\nabbr ls=eza" $bat_fullname > "$HOME/.config/zsh-abbr/user-abbreviations"
 
     sudo chsh -s /bin/zsh
 }

--- a/shared/shared_scripts.sh
+++ b/shared/shared_scripts.sh
@@ -140,7 +140,7 @@ function setup_zsh() {
     fi
     printf "abbr cat=%s\nabbr ls=eza" $bat_fullname > "$HOME/.config/zsh-abbr/user-abbreviations"
 
-    sudo chsh -s /bin/zsh
+    chsh -s /bin/zsh
 }
 
 function setup_starship_install() {


### PR DESCRIPTION
- **shared: added fix for bat alias when using debian based distros**
- **shared: onlyoffice flatpak added, all: golang added**
- **all: golang corrected, gamingoverlays is a single option, rearranged packages**
- **all: xampp added**
- **shared: xampp installer fixed**
- **fedora: don't autoremove libreoffice and install the flatpak**
- **config: firefox policy has third party cookies blocked**
- **fedora: codecs will be installed by the multimedia group**
- **firefox: dark reader and enhancer for youtube removed from being preinstalled, only privacy focused remain**
- **firefox: removed cookies settings, they didn't change anything**
- **debian: give warning when eza is already installed**
- **firefox: add the clearurls extension**
- **firefox: pocket, email tracking, autofill address and creditcard disabled**
- **firefox: default bookmarks removed**
- **firefox: feedback commands disabled**
- **shared: shell to zsh for user instead of root**
- **shared: echo if starship is installed, fixed check for prezto, fedora: allow erasing when installing codecs**

closes #67 
closes #65 
closes #69 